### PR TITLE
Fix token validation and add tests

### DIFF
--- a/telebot/util.py
+++ b/telebot/util.py
@@ -686,16 +686,21 @@ def validate_web_app_data(token: str, raw_init_data: str):
     return hmac.new(secret_key.digest(), data_check_string.encode(), sha256).hexdigest() == init_data_hash
 
 
-def validate_token(token) -> bool:        
+def validate_token(token) -> bool:
     if any(char.isspace() for char in token):
         raise ValueError('Token must not contain spaces')
-    
-    if ':' not in token:
-        raise ValueError('Token must contain a colon')
-    
-    if len(token.split(':')) != 2:
-        raise ValueError('Token must contain exactly 2 parts separated by a colon')
-    
+
+    parts = token.split(':')
+    if len(parts) != 2:
+        raise ValueError('Token must contain exactly one colon separating two parts')
+
+    bot_id, secret = parts
+    if not bot_id or not secret:
+        raise ValueError('Token must not have empty sections')
+
+    if not bot_id.isdigit():
+        raise ValueError('Bot ID must be numeric')
+
     return True
 
 def extract_bot_id(token) -> Union[int, None]:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,23 @@
+import pytest
+
+from telebot import util
+
+
+def test_validate_token_invalid_tokens():
+    with pytest.raises(ValueError):
+        util.validate_token(':token')
+    with pytest.raises(ValueError):
+        util.validate_token('1234:')
+    with pytest.raises(ValueError):
+        util.validate_token('1234:abcd:extra')
+    with pytest.raises(ValueError):
+        util.validate_token('12a4:abcd')
+
+
+def test_validate_token_valid():
+    assert util.validate_token('1234:abcd') is True
+
+
+def test_extract_bot_id():
+    assert util.extract_bot_id('1234:abcd') == 1234
+    assert util.extract_bot_id('bad') is None


### PR DESCRIPTION
## Summary
- tighten validation logic for bot tokens
- add regression tests for util.validate_token and extract_bot_id

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849158ae1ec8325bbf22a6d22e448fc