### PR TITLE
Fix retrievals typo

### DIFF
--- a/docs/source/locales/en/LC_MESSAGES/async_version.po
+++ b/docs/source/locales/en/LC_MESSAGES/async_version.po
@@ -3206,7 +3206,7 @@ msgid "Do not stop polling when an ApiException occurs."
 msgstr ""
 
 #: of telebot.async_telebot.AsyncTeleBot.polling:23
-msgid "Delay between two update retrivals"
+msgid "Delay between two update retrievals"
 msgstr ""
 
 #: of telebot.async_telebot.AsyncTeleBot.polling:42

--- a/docs/source/locales/en/LC_MESSAGES/sync_version.po
+++ b/docs/source/locales/en/LC_MESSAGES/sync_version.po
@@ -3047,7 +3047,7 @@ msgid "Use :meth:`infinity_polling` instead."
 msgstr ""
 
 #: of telebot.TeleBot.polling:15
-msgid "Delay between two update retrivals"
+msgid "Delay between two update retrievals"
 msgstr ""
 
 #: of telebot.TeleBot.polling:18

--- a/docs/source/locales/ru/LC_MESSAGES/async_version.po
+++ b/docs/source/locales/ru/LC_MESSAGES/async_version.po
@@ -3716,7 +3716,7 @@ msgid "Do not stop polling when an ApiException occurs."
 msgstr "Не останавливать поллинг при возникновении ApiException."
 
 #: of telebot.async_telebot.AsyncTeleBot.polling:23
-msgid "Delay between two update retrivals"
+msgid "Delay between two update retrievals"
 msgstr "Задержка между получением апдейтов"
 
 #: of telebot.async_telebot.AsyncTeleBot.polling:42

--- a/docs/source/locales/ru/LC_MESSAGES/sync_version.po
+++ b/docs/source/locales/ru/LC_MESSAGES/sync_version.po
@@ -3594,7 +3594,7 @@ msgid "Use :meth:`infinity_polling` instead."
 msgstr "Используйте :meth:`infinity_polling`."
 
 #: of telebot.TeleBot.polling:15
-msgid "Delay between two update retrivals"
+msgid "Delay between two update retrievals"
 msgstr "Задержка между получением апдейтов"
 
 #: of telebot.TeleBot.polling:18

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1142,7 +1142,7 @@ class TeleBot:
         
             Install watchdog and psutil before using restart_on_change option.
 
-        :param interval: Delay between two update retrivals
+        :param interval: Delay between two update retrievals
         :type interval: :obj:`int`
 
         :param non_stop: Do not stop polling when an ApiException occurs.

--- a/telebot/async_telebot.py
+++ b/telebot/async_telebot.py
@@ -281,7 +281,7 @@ class AsyncTeleBot:
         :param skip_pending: skip old updates
         :type skip_pending: :obj:`bool`
 
-        :param interval: Delay between two update retrivals
+        :param interval: Delay between two update retrievals
         :type interval: :obj:`int`
 
         :param timeout: Request connection timeout
@@ -418,7 +418,7 @@ class AsyncTeleBot:
         Function to process polling.
 
         :param non_stop: Do not stop polling when an ApiException occurs.
-        :param interval: Delay between two update retrivals
+        :param interval: Delay between two update retrievals
         :param timeout: Request connection timeout
         :param request_timeout: Timeout in seconds for long polling (see API docs)
         :param allowed_updates: A list of the update types you want your bot to receive.


### PR DESCRIPTION
## Summary
- fix docstring typos in polling options
- update PO files for the corrected text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68491d9be174832591dcb13b7ca3cb49