### PR TITLE
Add Railway deployment docs

### DIFF
--- a/docs/source/deploy_railway.rst
+++ b/docs/source/deploy_railway.rst
@@ -1,0 +1,16 @@
+====================
+Deploying on Railway
+====================
+
+.. meta::
+   :description: Deploying pyTelegramBotAPI bots on Railway
+   :keywords: pyTelegramBotAPI, Railway, deployment, hosting
+
+This guide shows a minimal example of running a bot on `Railway <https://railway.app>`_.
+
+1. Create a new **Python** project on Railway.
+2. Add your bot code (for example :download:`examples/echo_bot.py <../../examples/echo_bot.py>`)
+   to the repository. Place your token in an environment variable named ``BOT_TOKEN``.
+3. Set the start command to ``python echo_bot.py``.
+4. In ``requirements.txt`` include ``pyTelegramBotAPI``.
+5. Deploy the project. Your bot will start polling for updates.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -55,6 +55,7 @@ Content
    calldata
    util
    formatting
+   deploy_railway
 
 
 


### PR DESCRIPTION
## Summary
- document how to deploy a pyTelegramBotAPI bot on Railway
- fix title length and example link

## Testing
- `pytest -q`
- `sphinx-build -b html docs/source docs/_build/html`

------
https://chatgpt.com/codex/tasks/task_e_6849200b911c83258ff87e754c035f3f