### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ bot.infinity_polling()
 ```
 
 ### Using web hooks
-When using webhooks telegram sends one Update per call, for processing it you should call process_new_messages([update.message]) when you recieve it.
+When using webhooks telegram sends one Update per call, for processing it you should call process_new_messages([update.message]) when you receive it.
 
 There are some examples using webhooks in the [examples/webhook_examples](examples/webhook_examples) directory.
 


### PR DESCRIPTION
## Summary
- correct a misspelling in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684948fbda748325993b2c593de293d6