### PR TITLE
Add italic formatting test and fix output

### DIFF
--- a/telebot/formatting.py
+++ b/telebot/formatting.py
@@ -108,7 +108,7 @@ def mitalic(content: str, escape: Optional[bool]=True) -> str:
     :return: The formatted string.
     :rtype: :obj:`str`
     """
-    return '_{}_\r'.format(escape_markdown(content) if escape else content)
+    return '_{}_'.format(escape_markdown(content) if escape else content)
 
 
 def hitalic(content: str, escape: Optional[bool]=True) -> str:

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,0 +1,5 @@
+from telebot import formatting
+
+
+def test_mitalic():
+    assert formatting.mitalic('abc') == '_abc_'


### PR DESCRIPTION
## Summary
- add a regression test for `formatting.mitalic`
- fix `mitalic` to return proper underscore wrapping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68491d9ea94883258d1ff2d2b2e68bf0